### PR TITLE
fix: mediaInfo가 null로 바뀔 때 mediaPlayer를 제거한다

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -951,6 +951,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void clearMediaInfo() {
+        if (exoPlayerNotificationManager == null) {
+            return;
+        }
         exoPlayerNotificationManager.setPlayer(null);
         exoPlayerNotificationManager = null;
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -495,8 +495,7 @@ class ReactExoplayerView extends FrameLayout implements
             player = null;
         }
         if (exoPlayerNotificationManager != null) {
-            exoPlayerNotificationManager.setPlayer(null);
-            exoPlayerNotificationManager = null;
+            this.clearMediaInfo();
         }
         progressHandler.removeMessages(SHOW_PROGRESS);
         themedReactContext.removeLifecycleEventListener(this);
@@ -949,6 +948,11 @@ class ReactExoplayerView extends FrameLayout implements
     public void setMediaInfo(String title, String artist, String channelName) {
         exoPlayerNotificationManager = new ExoPlayerNotificationManager(getContext(), title, artist, channelName);
         exoPlayerNotificationManager.setPlayer(player);
+    }
+
+    public void clearMediaInfo() {
+        exoPlayerNotificationManager.setPlayer(null);
+        exoPlayerNotificationManager = null;
     }
 
     public void setProgressUpdateInterval(final float progressUpdateInterval) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -145,6 +145,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_MEDIA_INFO)
     public void setMediaInfo(final ReactExoplayerView videoView, @Nullable ReadableMap mediaInfo) {
       if (mediaInfo == null) {
+          videoView.clearMediaInfo();
         return;
       }
 


### PR DESCRIPTION
- mediaInfo가 Null로 바뀔 때 현재 mediaPlayer를 제거하도록 하였습니다.