### PR TITLE
fix: 이미지가 gif일 때 크래시가 안나도록 수정한다

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
@@ -18,6 +18,7 @@ import com.google.android.exoplayer2.ui.PlayerNotificationManager;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ClassCastException;
 import java.net.URL;
 
 public class ExoPlayerNotificationManager {
@@ -36,6 +37,9 @@ public class ExoPlayerNotificationManager {
             Drawable d = Drawable.createFromStream(is, params[1]);
             return ((BitmapDrawable) d).getBitmap();
           } catch (IOException e) {
+            e.printStackTrace();
+          } catch (ClassCastException e) {
+            // 이미지가 gif인 경우에 ClassCastException이 난다
             e.printStackTrace();
           }
           return null;


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/class101-api/crashlytics/app/android:net.pedaling.class101/issues/c644deb8f613e10f2605a39ef3746197?time=last-seven-days&versions=0.17.16%20(2012152117)&sessionEventKey=5FDC70BB01690001208CB2531D408E5F_1485965648178917460

크래시가 안나도록 수정하였습니다