### PR TITLE
fix: 안드로이드에서 썸네일 이미지가 클 때 발생하는 앱 크래시를 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn.lock
 
 # editor workspace settings
 .vscode
+.history/
 
 # BUCK
 buck-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### next
+* Added PictureInPicture support for AndroidExoplayer API >= 28. [#1776](https://github.com/react-native-community/react-native-video/pull/1776)
+
 ### Version 5.0.1
 * Fix AndroidX Support bad merge
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
@@ -86,9 +86,9 @@ public class ExoPlayerNotificationManager {
     final String CHANNEL_ID = "@class101/player_controller";
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel mChannel = new NotificationChannel(
-              CHANNEL_ID,
-              channelName,
-              NotificationManager.IMPORTANCE_LOW
+        CHANNEL_ID,
+        channelName,
+        NotificationManager.IMPORTANCE_LOW
       );
       notificationManager.createNotificationChannel(mChannel);
     }
@@ -100,10 +100,10 @@ public class ExoPlayerNotificationManager {
     this.artwork = artwork != null ? loadImageFromURL(artwork, "artwork") : null;
 
     this.playerNotificationManager = new PlayerNotificationManager(
-            context,
-            CHANNEL_ID,
-            0,
-            new DescriptionAdapter()
+      context,
+      CHANNEL_ID,
+      0,
+      new DescriptionAdapter()
     );
   }
 


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/class101-api/crashlytics/app/android:net.pedaling.class101/issues/24ffaf9fe43f37d27903fb0a3d3e1c0f
https://console.firebase.google.com/u/0/project/class101-api/crashlytics/app/android:net.pedaling.class101/issues/c644deb8f613e10f2605a39ef3746197

- 안드로이드에서 썸네일 이미지의 크기가 클 때 발생하는 OOM 앱 크래시를 수정
- 이미지 크기가 큰 경우 OutOfMemory 에러 발생, 썸네일 이미지가 기기의 알림 탭에서 사용할 수 있는 이미지 크기보다 큰 경우 샘플링해서 불러오도록 수정