### PR TITLE
fix: 안드로이드에서 PiP 모드 비활성화 시 발생하는 에러는 무시한다

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1382,11 +1382,16 @@ class ReactExoplayerView extends FrameLayout implements
                 && packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) {
             long videoPosition = player.getCurrentPosition();
             Activity activity = themedReactContext.getCurrentActivity();
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                PictureInPictureParams.Builder params = new PictureInPictureParams.Builder();
-                activity.enterPictureInPictureMode(params.build());
-            } else {
-                activity.enterPictureInPictureMode();
+
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    PictureInPictureParams.Builder params = new PictureInPictureParams.Builder();
+                    activity.enterPictureInPictureMode(params.build());
+                } else {
+                    activity.enterPictureInPictureMode();
+                }
+            } catch (IllegalStateException ignore) {
+                // ignore if PIP mode is disabled
             }
         }
     }


### PR DESCRIPTION
- 안드로이드에서 PiP 모드를 사용할 수 없는 경우 발생하는 Exception은 무시하도록 수정한다.