### PR TITLE
fix: 안드로이드에서 앱 종료 후에도 알림 센터에 컨트롤러가 남아있는 이슈를 수정한다

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
@@ -82,6 +82,10 @@ public class ExoPlayerNotificationManager {
   public ExoPlayerNotificationManager(Context context, String title, String artist, String channelName, String artwork) {
     this.context = context;
 
+    this.title = title;
+    this.artist = artist;
+    this.artwork = artwork != null ? loadImageFromURL(artwork, "artwork") : null;
+
     NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -93,18 +97,14 @@ public class ExoPlayerNotificationManager {
       notificationManager.createNotificationChannel(mChannel);
     }
 
-    context.startService(new Intent(context,KillNotificationService.class));
-
-    this.title = title;
-    this.artist = artist;
-    this.artwork = artwork != null ? loadImageFromURL(artwork, "artwork") : null;
-
     this.playerNotificationManager = new PlayerNotificationManager(
       context,
       CHANNEL_ID,
       NOTIFICATION_ID,
       new DescriptionAdapter()
     );
+
+    context.startService(new Intent(context, KillNotificationService.class));
   }
 
   public void setPlayer(SimpleExoPlayer player) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
@@ -4,14 +4,11 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.R;
-import android.util.Log;
 
 import androidx.annotation.Nullable;
 
@@ -21,10 +18,12 @@ import com.google.android.exoplayer2.ui.PlayerNotificationManager;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class ExoPlayerNotificationManager {
+  public static final String CHANNEL_ID = "@class101/player_controller";
+  public static final int NOTIFICATION_ID = 0;
+
   private String title;
   private String artist;
   private Bitmap artwork;
@@ -81,9 +80,10 @@ public class ExoPlayerNotificationManager {
   }
 
   public ExoPlayerNotificationManager(Context context, String title, String artist, String channelName, String artwork) {
+    this.context = context;
+
     NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-    final String CHANNEL_ID = "@class101/player_controller";
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel mChannel = new NotificationChannel(
         CHANNEL_ID,
@@ -93,7 +93,7 @@ public class ExoPlayerNotificationManager {
       notificationManager.createNotificationChannel(mChannel);
     }
 
-    this.context = context;
+    context.startService(new Intent(context,KillNotificationService.class));
 
     this.title = title;
     this.artist = artist;
@@ -102,7 +102,7 @@ public class ExoPlayerNotificationManager {
     this.playerNotificationManager = new PlayerNotificationManager(
       context,
       CHANNEL_ID,
-      0,
+      NOTIFICATION_ID,
       new DescriptionAdapter()
     );
   }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
@@ -1,0 +1,24 @@
+package com.brentvatne.exoplayer;
+
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+public class KillNotificationService extends Service {
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+    return null;
+  }
+
+  @Override
+  public void onTaskRemoved(Intent rootIntent) {
+    NotificationManager notificationManager =
+      (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+
+    notificationManager.cancel(ExoPlayerNotificationManager.NOTIFICATION_ID);
+  }
+}


### PR DESCRIPTION
- 안드로이드에서 앱 종료를 모니터링하고, 앱이 종료된 경우 알림 센터의 컨트롤러를 삭제하는 서비스 추가