### PR TITLE
fix: 안드로이드 오레오 이후 버전이면 서비스를 foreground에서 실행한다

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerNotificationManager.java
@@ -104,7 +104,14 @@ public class ExoPlayerNotificationManager {
       new DescriptionAdapter()
     );
 
-    context.startService(new Intent(context, KillNotificationService.class));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Intent killNotificationServiceIntent = new Intent(context, KillNotificationService.class);
+      killNotificationServiceIntent.putExtra("channelName", channelName);
+
+      context.startForegroundService(killNotificationServiceIntent);
+    } else {
+      context.startService(new Intent(context, KillNotificationService.class));
+    }
   }
 
   public void setPlayer(SimpleExoPlayer player) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
@@ -1,17 +1,58 @@
 package com.brentvatne.exoplayer;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
 
 public class KillNotificationService extends Service {
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
     return null;
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      final String channelName = intent.getStringExtra("channelName");
+
+      NotificationManager notificationManager =
+        (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+      NotificationChannel channel =
+        notificationManager.getNotificationChannel(ExoPlayerNotificationManager.CHANNEL_ID);
+
+      if (channel == null) {
+        channel = new NotificationChannel(
+          ExoPlayerNotificationManager.CHANNEL_ID,
+          channelName,
+          NotificationManager.IMPORTANCE_LOW
+        );
+        notificationManager.createNotificationChannel(channel);
+      }
+
+      Notification notification =
+        new NotificationCompat.Builder(this, ExoPlayerNotificationManager.CHANNEL_ID).build();
+      startForeground(1, notification);
+    }
+
+    return super.onStartCommand(intent, flags, startId);
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      stopForeground(true);
+    }
   }
 
   @Override


### PR DESCRIPTION
- https://console.firebase.google.com/project/class101-api/crashlytics/app/android:net.pedaling.class101/issues/aabbd5f588fd3b90381b14aadcf1fa0c?time=last-thirty-days&versions=0.18.6%20(2073865002);0.18.6%20(2073847352)&sessionEventKey=60516711038500014992C1CB852D9CF5_1518913273115132744
- 안드로이드 오레오 버전 이후인 경우에는 백그라운드 서비스를 실행할 수 없음 https://developer.android.com/about/versions/oreo/background.html
- 안드로이드 오레오 버전 이후인 경우, KillNotificationService를 foreground service 로 실행하도록 수정