### PR TITLE
fix: intent가 null일 때의 처리 추가

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/KillNotificationService.java
@@ -13,6 +13,9 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
 public class KillNotificationService extends Service {
+  public static final String CHANNEL_ID = "@class101/kill_player_controller";
+  public static final String DEFAULT_CHANNEL_NAME = "클래스101 영상 컨트롤러";
+
   @Nullable
   @Override
   public IBinder onBind(Intent intent) {
@@ -22,16 +25,17 @@ public class KillNotificationService extends Service {
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      final String channelName = intent.getStringExtra("channelName");
+      final String channelName = intent != null ?
+        intent.getStringExtra("channelName") : DEFAULT_CHANNEL_NAME;
 
       NotificationManager notificationManager =
-        (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
       NotificationChannel channel =
-        notificationManager.getNotificationChannel(ExoPlayerNotificationManager.CHANNEL_ID);
+        notificationManager.getNotificationChannel(CHANNEL_ID);
 
       if (channel == null) {
         channel = new NotificationChannel(
-          ExoPlayerNotificationManager.CHANNEL_ID,
+          CHANNEL_ID,
           channelName,
           NotificationManager.IMPORTANCE_LOW
         );
@@ -39,7 +43,7 @@ public class KillNotificationService extends Service {
       }
 
       Notification notification =
-        new NotificationCompat.Builder(this, ExoPlayerNotificationManager.CHANNEL_ID).build();
+        new NotificationCompat.Builder(this, CHANNEL_ID).build();
       startForeground(1, notification);
     }
 
@@ -50,16 +54,24 @@ public class KillNotificationService extends Service {
   public void onDestroy() {
     super.onDestroy();
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      stopForeground(true);
-    }
+    killNotification();
   }
 
   @Override
   public void onTaskRemoved(Intent rootIntent) {
+    super.onTaskRemoved(rootIntent);
+
+    killNotification();
+  }
+
+  private void killNotification() {
     NotificationManager notificationManager =
       (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 
     notificationManager.cancel(ExoPlayerNotificationManager.NOTIFICATION_ID);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      stopForeground(true);
+    }
   }
 }


### PR DESCRIPTION
- https://console.firebase.google.com/project/class101-api/crashlytics/app/android:net.pedaling.class101/issues/36d3769f5274ac3959cd71e01a1f8643?time=last-seven-days&sessionEventKey=60594377030400015C2B546CE7BC60F5_1521100082135473217
- intent가 null인 경우가 있어 해당 처리를 추가했습니다.