### PR TITLE
fix: 안드로이드 앱 영상 재생 및 일시정지 때마다 진동이 울리는 현상을 수정한다 (CM-187, QA101-673)

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1126,6 +1126,7 @@ class ReactExoplayerView extends FrameLayout implements
                     notificationChannelName != null ? notificationChannelName : CHANNEL_ID,
                     NotificationManager.IMPORTANCE_DEFAULT);
             channel.setDescription(CHANNEL_ID);
+            channel.setSound(null, null);
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
             notificationManager.createNotificationChannel(channel);


### PR DESCRIPTION
https://101inc.atlassian.net/browse/CM-187 https://101inc.atlassian.net/browse/QA101-673

- 안드로이드에서 영상 재생 또는 일시정지 시 알림음/진동이 발생하는 현상을 수정했습니다.
- 미디어 컨트롤러가 알림으로 등록이 되는데, 알림 채널의 소리 설정이 기본값으로 되어있어 알림음/진동이 발생했습니다. https://developer.android.com/reference/android/app/NotificationChannel#setSound(android.net.Uri,%20android.media.AudioAttributes)
- 미디어 컨트롤러의 알림 채널에 소리 설정을 null로 변경하여 알림음/진동이 발생하지 않도록 수정했습니다.