### PR TITLE
fix: DRM 라이센스 요청을 비디오별로 하도록 수정한다

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -23,14 +23,14 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.9.3') {
+    implementation('com.google.android.exoplayer:exoplayer:2.13.2') {
         exclude group: 'com.android.support'
     }
 
     // All support libs must use the same version
-    implementation "androidx.annotation:annotation:1.0.0"
-    implementation "androidx.core:core:1.0.0"
-    implementation "androidx.media:media:1.0.0"
+    implementation "androidx.annotation:annotation:1.1.0"
+    implementation "androidx.core:core:1.1.0"
+    implementation "androidx.media:media:1.1.0"
 
     implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'

--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.9.3') {
+    implementation('com.google.android.exoplayer:extension-okhttp:2.13.2') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/AspectRatioFrameLayout.java
@@ -67,6 +67,10 @@ public final class AspectRatioFrameLayout extends FrameLayout {
         return videoAspectRatio;
     }
 
+    public void invalidateAspectRatio() {
+        videoAspectRatio = 0;
+    }
+
     /**
      * Sets the resize mode which can be of value {@link ResizeMode.Mode}
      *

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -17,10 +17,12 @@ import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.video.VideoListener;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.text.Cue;
 import com.google.android.exoplayer2.text.TextRenderer;
+import com.google.android.exoplayer2.text.TextOutput;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.ui.SubtitleView;
 
@@ -84,6 +86,14 @@ public final class ExoPlayerView extends FrameLayout {
         addViewInLayout(layout, 0, aspectRatioParams);
     }
 
+    private void clearVideoView() {
+        if (surfaceView instanceof TextureView) {
+            player.clearVideoTextureView((TextureView) surfaceView);
+        } else if (surfaceView instanceof SurfaceView) {
+            player.clearVideoSurfaceView((SurfaceView) surfaceView);
+        }
+    }
+
     private void setVideoView() {
         if (surfaceView instanceof TextureView) {
             player.setVideoTextureView((TextureView) surfaceView);
@@ -112,8 +122,8 @@ public final class ExoPlayerView extends FrameLayout {
     }
 
     /**
-     * Set the {@link SimpleExoPlayer} to use. The {@link SimpleExoPlayer#setTextOutput} and
-     * {@link SimpleExoPlayer#setVideoListener} method of the player will be called and previous
+     * Set the {@link SimpleExoPlayer} to use. The {@link SimpleExoPlayer#addTextOutput} and
+     * {@link SimpleExoPlayer#addVideoListener} method of the player will be called and previous
      * assignments are overridden.
      *
      * @param player The {@link SimpleExoPlayer} to use.
@@ -123,18 +133,18 @@ public final class ExoPlayerView extends FrameLayout {
             return;
         }
         if (this.player != null) {
-            this.player.setTextOutput(null);
-            this.player.setVideoListener(null);
+            this.player.removeTextOutput(componentListener);
+            this.player.removeVideoListener(componentListener);
             this.player.removeListener(componentListener);
-            this.player.setVideoSurface(null);
+            clearVideoView();
         }
         this.player = player;
         shutterView.setVisibility(VISIBLE);
         if (player != null) {
             setVideoView();
-            player.setVideoListener(componentListener);
+            player.addVideoListener(componentListener);
             player.addListener(componentListener);
-            player.setTextOutput(componentListener);
+            player.addTextOutput(componentListener);
         }
     }
 
@@ -199,8 +209,13 @@ public final class ExoPlayerView extends FrameLayout {
         shutterView.setVisibility(VISIBLE);
     }
 
-    private final class ComponentListener implements SimpleExoPlayer.VideoListener,
-            TextRenderer.Output, ExoPlayer.EventListener {
+    public void invalidateAspectRatio() {
+        // Resetting aspect ratio will force layout refresh on next video size changed
+        layout.invalidateAspectRatio();
+    }
+
+    private final class ComponentListener implements VideoListener,
+            TextOutput, ExoPlayer.EventListener {
 
         // TextRenderer.Output implementation
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/RawResourceDataSourceFactory.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/RawResourceDataSourceFactory.java
@@ -15,6 +15,6 @@ class RawResourceDataSourceFactory implements DataSource.Factory {
 
     @Override
     public DataSource createDataSource() {
-        return new RawResourceDataSource(context, null);
+        return new RawResourceDataSource(context);
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -496,7 +496,6 @@ class ReactExoplayerView extends FrameLayout implements
                 if (playerNeedsSource && srcUri != null) {
                     exoPlayerView.invalidateAspectRatio();
 
-                    ArrayList<MediaSource> mediaSourceList = buildTextSources();
                     DrmSessionManager drmSessionManager = null;
 
                     if (self.drmLicenseServerUrl != null && self.drmUserAuthToken != null && self.drmContentId != null) {
@@ -516,6 +515,7 @@ class ReactExoplayerView extends FrameLayout implements
                             return;
                         }
                     }
+                    ArrayList<MediaSource> mediaSourceList = buildTextSources();
                     MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
                     MediaSource mediaSource;
                     if (mediaSourceList.size() == 0) {


### PR DESCRIPTION
- exoplayer가 2.12부터 비디오 로딩 때 라이센스를 포함할 수 있어서 exoplayer의 버전을 올렸습니다
  - 기존 코드를 새 exoplayer에 맞게 대응하였습니다
- drmSession을 비디오를 요청할 때 만들도록 하였습니다 